### PR TITLE
Feature: Status code in test runner responses

### DIFF
--- a/test-runner.js
+++ b/test-runner.js
@@ -57,11 +57,16 @@ async function run() {
                 jar: cookieJar,
                 resolveWithFullResponse: true,
             };
-            let res = { error: 404 };
+            let res = { body: { error: 404 }};
+
             try {
                 res = await request( req );
+            } catch (e) {
+                res = {
+                    statusCode: e.statusCode,
+                }
             }
-            catch ( e ) { }
+
             if ( typeof res.body === 'string' ) {
                 try {
                     res.body = JSON.parse( res.body );

--- a/test-runner.js
+++ b/test-runner.js
@@ -54,22 +54,33 @@ async function run() {
                 method: q.method,
                 'content-type': 'application/json',
                 json: q.body,
-                jar: cookieJar
+                jar: cookieJar,
+                resolveWithFullResponse: true,
             };
             let res = { error: 404 };
             try {
                 res = await request( req );
             }
             catch ( e ) { }
-            if ( typeof res === 'string' ) {
+            if ( typeof res.body === 'string' ) {
                 try {
-                    res = JSON.parse( res );
+                    res.body = JSON.parse( res.body );
                 }
                 catch ( e ) {
-                    res = { nonJSON: res };
+                    res.body = { nonJSON: res.body };
                 }
             }
-            Object.assign( response, res );
+
+            const { statusCode } = res;
+
+            // keep the body, add the statusCode, so we don't have to rewrite stuff
+            const customResponseObject = {
+                ...res.body,
+                statusCode,
+            };
+
+            Object.assign( response, customResponseObject );
+
             req.json && ( req.body = req.json );
             delete req['content-type'];
             delete req.json;
@@ -77,7 +88,7 @@ async function run() {
             let t = {
                 name: query.name,
                 request: { ...req },
-                response: res,
+                response: customResponseObject,
                 tests: [],
                 status: 'passed'
             };


### PR DESCRIPTION
# Reason for change

I wanted to check the status codes of the responses in the test runner, but only the response body was being supplied to the tests.

## Changes implemented

Add the response status code to the response body before passing it to the tests. This should ensure that we do not need to rewrite any tests, whilst also giving us access to http status codes of responses for testing purposes. It can lead to conflicts of the response actually contains a property called statusCode, but that really shouldn't happen.

### How to test

Run some tests as usual and make sure everything still works as expected. Observe that in the response info in the test runner log, the status code of the response is included. Do some assertions against the status code to make sure it works. 