### PR TITLE
Fix: Send money to self

### DIFF
--- a/routes/send-money.js
+++ b/routes/send-money.js
@@ -41,9 +41,9 @@ function sendMoney(app) {
             // show me the money
             const transaction = new Transaction({
                 recipient: actualRecipient._id,
+                sender: sender._id,
                 amount,
                 message,
-                sender
             });
 
             const result = await transaction.save();
@@ -52,17 +52,12 @@ function sendMoney(app) {
             if (actualRecipient.id !== senderId) {
 
                 // decrease senders money on account
-                let remainingTransactionsFromSender =
-                    transaction.sender.balance - transaction.amount;
-
-                sender.balance = remainingTransactionsFromSender;
+                sender.balance -= transaction.amount;
 
                 await sender.save();
 
                 // increase recipients money on account
-                let remainingTransactionsFromRecipient = actualRecipient.balance + transaction.amount;
-
-                actualRecipient.balance = remainingTransactionsFromRecipient;
+                actualRecipient.balance += transaction.amount;
 
                 await actualRecipient.save();
 

--- a/routes/send-money.js
+++ b/routes/send-money.js
@@ -48,23 +48,27 @@ function sendMoney(app) {
 
             const result = await transaction.save();
 
-            // decrease senders money on account
-            let remainingTransactionsFromSender =
-                transaction.sender.balance - transaction.amount;
+            // only adjust balance if sender and recipient are different accounts
+            if (actualRecipient.id !== senderId) {
 
-            sender.balance = remainingTransactionsFromSender;
+                // decrease senders money on account
+                let remainingTransactionsFromSender =
+                    transaction.sender.balance - transaction.amount;
 
-            await sender.save();
+                sender.balance = remainingTransactionsFromSender;
 
-            // increase recipients money on account
-            let remainingTransactionsFromRecipient = actualRecipient.balance + transaction.amount;
+                await sender.save();
 
-            actualRecipient.balance = remainingTransactionsFromRecipient;
+                // increase recipients money on account
+                let remainingTransactionsFromRecipient = actualRecipient.balance + transaction.amount;
 
-            await actualRecipient.save();
+                actualRecipient.balance = remainingTransactionsFromRecipient;
+
+                await actualRecipient.save();
+
+            }
 
             res.json(result);
-
 
         } catch (error) {
             res.status(500).json(error);


### PR DESCRIPTION
The updating of balance logic did not play well when the sender and the recipient was the same, so now we bypass that completely if the sender and recipient is the same account.

## How to test:

Send some money to yourself, and see if you still can increase your balance this way.

Read through the changes and look for any other features that might break as a result of these changes

Happy testing!