### PR TITLE
Fix: encrypt password on reset

### DIFF
--- a/routes/reset-password.js
+++ b/routes/reset-password.js
@@ -1,5 +1,6 @@
 const User = require("../mongoose-models/user.model");
 const sendEmail = require("../send-email");
+const encryptPassword = require('../helpers/encrypt-password');
 
 function resetPassword(app) {
 	// this is the route a user can call when they have forgotten their password
@@ -22,7 +23,7 @@ function resetPassword(app) {
 		// send email to the user with the password reset link
 		sendEmail({
 			to: user.email,
-			html: `<body><p>Click this link to get a new assword and a free iPad - ${link}</p></body>`,
+			html: `<body><p>Click this link to get a new password - ${link}</p></body>`,
 			subject: "PayWay - Reset Password NO REPLY"
 		});
 
@@ -42,15 +43,15 @@ function resetPassword(app) {
 			// get the user
 			const user = await User.findById(req.params.id);
 
-			// change the password
-			user.password = password;
+			// change the password (encrypt before saving)
+			user.password = encryptPassword(password);
 			await user.save();
 
-			// notify the user with mail
+			// notify the user with mail (send them the unencrypted pwd)
 			sendMailWithNewPassword(user.email, password);
 
 			res.send(
-				"We have sent an email to you containing your new assword. You can use this assword to login."
+				"We have sent an email to you containing your new password. You can now use this password to login."
 			);
 		} catch (error) {
 			// respond with status 500 (internal server error) to let frontend know there was an error when processing
@@ -68,7 +69,7 @@ function sendMailWithNewPassword(email, password) {
 	sendEmail({
 		to: email,
 		subject: "PayWay - New password",
-		html: `<body><p>Hi! Your new password is ${password}. You can now user your new password to log into PayWay. We recommend that you change this password to something more fun.`
+		html: `<body><p>Hi! Your new password is ${password}. You can now use your new password to log into PayWay. We recommend that you change this password to something more fun and perhaps a bit naughty (but only if you feel like it).`
 	});
 }
 


### PR DESCRIPTION
## Password encryption on reset

Used the same function to encrypt password when user resets that we do when registering. I tested it with my own email and it seemed to work.

## How to test

I don't think there is a frontend interface for this, so look at the reset password route to see how you should shape your request to ask for a reset of your an account where you have access to the email address. Click the link and try logging in with your new password. Double check that the password is not stored in plain text in the db.