### PR TITLE
Feature/limit send money

### DIFF
--- a/frontend/src/components/ContextKeeper.jsx
+++ b/frontend/src/components/ContextKeeper.jsx
@@ -51,7 +51,7 @@ const ContextKeeper = props => {
     return (
         <div>
             <Row>
-                <Col s={12} l={3} offset='l4'>
+                <Col s={12} m={6} l={3} offset='l4 m3'>
                     {props.children}
                 </Col>
             </Row>

--- a/frontend/src/components/FavouritesList/FavouritesList.jsx
+++ b/frontend/src/components/FavouritesList/FavouritesList.jsx
@@ -64,7 +64,7 @@ const FavouritesList = () => {
 
     return (
         <Row>
-            <Col m={6} s={12}>
+            <Col s={12}>
                 {favorites.length ?
                     <React.Fragment>
                         <h5 className="mb">My favorite contacts:</h5>

--- a/frontend/src/components/SendMoney/index.jsx
+++ b/frontend/src/components/SendMoney/index.jsx
@@ -253,7 +253,7 @@ const SendMoney = (props) => {
             </form>
 
             <div className="row">
-                <div className="col s12 l3 offset-l4">
+                <div className="col s12">
                     { loading ? preloader : null }
 
                     { showGenericErrorMessage ? genericErrorMessage : null }

--- a/frontend/src/components/SendMoney/index.jsx
+++ b/frontend/src/components/SendMoney/index.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useContext } from 'react';
 import MessageComponent from '../Message/MessageComponent';
 import { UserContext } from "../../AuthUserContext";
+import { Link } from "react-router-dom";
+
 
 
 const SendMoney = (props) => {
@@ -11,6 +13,7 @@ const SendMoney = (props) => {
 
     const [ showInvalidRecipientNotice, setShowInvalidRecipientNotice ] = useState(false);
     const [ showGenericErrorMessage, setShowGenericErrorMessage ] = useState(false);
+    const [ showOverLimitErrorMessage, setShowOverLimitErrorMessage ] = useState(false);
 
     const [ transactionStatus, setTransactionStatus ] = useState({ loading: false, loaded: false, error: false, status: null });
     
@@ -23,7 +26,9 @@ const SendMoney = (props) => {
     const { history } = props;
     const {user} = useContext(UserContext);
 
-
+    const isOverLimit = (amount) => {
+        return amount > user.limit ? true : false;
+    }
 
     // function to handle when form is submitted
     const handleSubmit = async (e) => {
@@ -33,6 +38,11 @@ const SendMoney = (props) => {
 
         // clear error status
         setShowGenericErrorMessage(false);
+
+        if(isOverLimit(transactionAmount)) {
+            setShowOverLimitErrorMessage(true);
+            return;
+        }
 
         // try to send money via API
         try {
@@ -93,6 +103,17 @@ const SendMoney = (props) => {
         <div className="row">
             <div className="col s12">
                 <span>Something went wrong! Make sure that your account has suffiecent funds and try again.</span>
+            </div>
+        </div>
+    );
+
+    const overLimitErrorMessage = (
+        <div className="row">
+            <div className="col s12" style={{padding: '5px 25px'}}>
+                <span>You've made an attempt to send more than your limit!</span>
+            </div>
+            <div className="col s12" style={{padding: '5px 25px'}}>
+                <span>Your limit is {user.limit}. You can change your limit in <Link title="Go to settings" to="/profile/settings">settings</Link>.</span>
             </div>
         </div>
     );
@@ -191,6 +212,7 @@ const SendMoney = (props) => {
                     { loading ? preloader : null }
 
                     { showGenericErrorMessage ? genericErrorMessage : null }
+                    {showOverLimitErrorMessage ? overLimitErrorMessage : null}
                 </div>
             </div>
             {showMMessage ? <MessageComponent 

--- a/frontend/src/components/addFavourite/CreateFavouriteComponent.jsx
+++ b/frontend/src/components/addFavourite/CreateFavouriteComponent.jsx
@@ -58,7 +58,7 @@ const CreateFavouriteComponent = () => {
         <React.Fragment>
             {!user ? <Redirect to='/login' /> : null}
             <Row>
-                <Col node="form" onSubmit={handleSubmit} s={12} m={4} offset="m4">
+                <Col node="form" onSubmit={handleSubmit} s={12}>
                     <h1>Add your favourite</h1>
 
                     <TextInput

--- a/routes/send-money.js
+++ b/routes/send-money.js
@@ -25,9 +25,19 @@ function sendMoney(app, socket) {
                 return res.status(500).send('sender does not exist in db');
             }
 
+            //check if sender try to send money to himself
+            if(recipient === sender.phone) {
+                return res.status(400).json({errorCode: 'selfie'});
+            }
+
             // check that sender has enogugh money
             if (sender.balance < amount) {
-                return res.status(400).send('You do not have enough money!');
+                return res.status(400).json('You do not have enough money!');
+            }
+
+            //check that amount is not over limit
+            if(sender.limit < amount) {
+                return res.status(400).json({errorCode: 'overLimit'});
             }
 
             // convert phone nr to string just in case
@@ -35,7 +45,7 @@ function sendMoney(app, socket) {
 
 
             if (!actualRecipient) {
-                return res.status(404).send('No such user');
+                return res.status(404).json('No such user');
             }
 
             // show me the money


### PR DESCRIPTION
Hello!
Feature to stop sending money over user's limit is introduced by this commit.

How to test:

- Log in
- Navigate to /profile/settings and change Amount limit to some reasonable, for example - 40. Click on Save button.
- Navigate to /send-money and try to send amount more than limit (in suggested case: 41). Error message appears (text under buttons Cancel and Send)
- In addition, try to send money to your phone, error message appears (in the same style as above mentioned)

NOTE: Among other things issue with duplicated transactions keys in the TransactionPage component is fixed. A key equals transaction.id, so if user sent money to himself/herself, this transaction is shown twice in the tab All transactions - 'minus amount' as well as 'plus amount', both rows have the same key (transaction.id). Therefore option 'sending money to himself' no longer available. By the way this option is meaningless because user has only one 'money account'.  but I know your pain, but sorry about that ))