### PR TITLE
Fix/bug with deleted user in transactions

### DIFF
--- a/frontend/src/components/Children/Contact.jsx
+++ b/frontend/src/components/Children/Contact.jsx
@@ -5,19 +5,23 @@ import { CollectionItem, Icon } from 'react-materialize';
 
 const Contact = (props) => {
     const { contact } = props;
-    return (
-        <CollectionItem className="avatar">
+
+    return (    
+        <React.Fragment> {contact ? <CollectionItem className="avatar">
             <Icon className="circle">
                 account_circle
-</Icon>
+            </Icon>
             <span className="title">
                 {contact.name}
             </span>
             <p>
                 {contact.phone}
             </p>
-        </CollectionItem>
+            </CollectionItem> : null}
+            
+        </React.Fragment>
     )
+    
 }
 
 

--- a/frontend/src/components/ContextKeeper.jsx
+++ b/frontend/src/components/ContextKeeper.jsx
@@ -51,7 +51,7 @@ const ContextKeeper = props => {
     return (
         <div>
             <Row>
-                <Col s={12} l={3} offset='l4'>
+                <Col s={12} m={6} l={4} xl={3} offset='xl4 l4 m2'>
                     {props.children}
                 </Col>
             </Row>

--- a/frontend/src/components/TransactionPage/TransactionPage.jsx
+++ b/frontend/src/components/TransactionPage/TransactionPage.jsx
@@ -47,7 +47,7 @@ const TransactionPage = () => {
                                 return (
                                     <Transaction
                                         className={"incoming"} 
-                                        contact={transaction.sender.name} 
+                                        contact={transaction.sender ? transaction.sender.name : 'deleted user\' name'}
                                         transaction={transaction} 
                                         key={transaction._id} 
                                         message={transaction.message}
@@ -59,7 +59,7 @@ const TransactionPage = () => {
                                 return (
                                 <Transaction 
                                     className={"outgoing"} 
-                                    contact={transaction.recipient.name} 
+                                    contact={transaction.recipient ? transaction.recipient.name : 'deleted user\' name'} 
                                     transaction={transaction} 
                                     key={transaction._id}
                                     message={transaction.message} 
@@ -70,15 +70,19 @@ const TransactionPage = () => {
         <React.Fragment>
             <Tabs className="tab-demo z-depth-1">
                 <Tab title="All" active>
-                    {data.map(transaction => {
+                    {data ? data.map(transaction => {
                         if (transaction.recipient === user._id) {
                             return (
-                                <Transaction className={"incoming"} contact={transaction.sender.name} transaction={transaction} key={transaction._id} />
+                                <Transaction className={"incoming"}
+                                contact={transaction.sender ? transaction.sender.name : 'deleted user\' name'}
+                                  transaction={transaction} key={transaction._id} />
                             )
                         } else {
-                            return (<Transaction className={"outgoing"} contact={transaction.recipient.name} transaction={transaction} key={transaction._id} />)
+                            return (<Transaction className={"outgoing"}
+                             contact={transaction.recipient ? transaction.recipient.name : 'deleted user\' name'}
+                              transaction={transaction} key={transaction._id} />)
                         }
-                    })}
+                    }) : null}
                 </Tab>
                 <Tab title="Incoming" > 
                     {incomingTransactions.length ? incomingTransactions : (<p>You have no incoming transactions.</p>)}


### PR DESCRIPTION
Hello!
It must never happen again to delete users from paywayapp db but sometimes it happens.
Fixed bug: cannot read name of null while creating Contact on TransactionPage in case of user (sender or recipient) was deleted from database.
How to test:
Delete user A who sent money to user B.
Check user's B transactions - it should shown "deleted user's name" instead of empty string or crashing errors in console.