### PR TITLE
fixed stuck errorMsg on loginPage

### DIFF
--- a/frontend/src/components/LoginPage/LoginPage.jsx
+++ b/frontend/src/components/LoginPage/LoginPage.jsx
@@ -17,6 +17,7 @@ const LoginPage = () => {
 
     const handleMessageUnmount = () => {
         setShowMessage(false);
+        setShowErrorMessage(false);
     }
 
     const onShowErrorMessage = (text) => {
@@ -62,7 +63,6 @@ const LoginPage = () => {
     const { inputs, handleInputChange, handleSubmit } = useLoginForm(onLogin);
 
     const onResetPassword = async () => {
-
         try {
             const response = await fetch('/api/reset-password', {
                 method: 'POST',


### PR DESCRIPTION
Fixed bug with stuck error message on LoginPage.
Bug was detected in test case when user first got error message (t.ex. no email address entered, or wrong credentials are used while logging in) and then clicks on Forgot your password? link.